### PR TITLE
[notifications] Remove CONFIG+=ordered.

### DIFF
--- a/notifications.pro
+++ b/notifications.pro
@@ -1,5 +1,7 @@
 TEMPLATE = subdirs
-CONFIG += ordered
-SUBDIRS = src src/plugin
 
-src/plugin.depends = src
+src_plugins.subdir = src/plugin
+src_plugins.target = sub-plugins
+src_plugins.depends = src
+
+SUBDIRS += src src_plugins


### PR DESCRIPTION
We can't do src/plugins.depends = src, so set up an intermediate target
explicitly pointing at the src/plugins directory and set the dependency on that.
