### PR TITLE
Separating notification data from Notification class

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -38,12 +38,28 @@
 #include <QVariantHash>
 #include <QDBusArgument>
 
+struct NotificationData
+{
+    NotificationData();
+    uint replacesId;
+    QString summary;
+    QString body;
+    QVariantHash hints;
+    QString remoteDBusCallServiceName;
+    QString remoteDBusCallObjectPath;
+    QString remoteDBusCallInterface;
+    QString remoteDBusCallMethodName;
+    QVariantList remoteDBusCallArguments;
+};
+
+class NotificationManagerProxy;
 class Q_DECL_EXPORT Notification : public QObject
 {
     Q_OBJECT
 
 public:
-    Notification(QObject *parent = 0);
+    explicit Notification(QObject *parent = 0);
+    virtual ~Notification();
 
     Q_PROPERTY(QString category READ category WRITE setCategory NOTIFY categoryChanged)
     QString category() const;
@@ -120,6 +136,8 @@ signals:
     void previewBodyChanged();
     void itemCountChanged();
     void remoteDBusCallChanged();
+protected:
+    QScopedPointer<NotificationData> data;
 
 private slots:
     void checkActionInvoked(uint id, QString actionKey);
@@ -127,21 +145,10 @@ private slots:
     void setRemoteActionHint();
 
 private:
-    static QString appName();
-
-    uint replacesId_;
-    QString summary_;
-    QString body_;
-    QVariantHash hints_;
-    QString remoteDBusCallServiceName_;
-    QString remoteDBusCallObjectPath_;
-    QString remoteDBusCallInterface_;
-    QString remoteDBusCallMethodName_;
-    QVariantList remoteDBusCallArguments_;
+    static Notification * createNotification(const NotificationData &data, QObject *parent = 0);
 };
 
-Q_DECLARE_METATYPE(Notification)
-Q_DECLARE_METATYPE(QList<Notification>)
-Q_DECLARE_METATYPE(QList<Notification*>)
+Q_DECLARE_METATYPE(NotificationData)
+Q_DECLARE_METATYPE(QList<NotificationData>)
 
 #endif // NOTIFICATION_H

--- a/src/org.freedesktop.Notifications.xml
+++ b/src/org.freedesktop.Notifications.xml
@@ -39,7 +39,7 @@
     <method name="GetNotifications">
       <arg name="app_name" type="s" direction="in"/>
       <arg name="notifications" type="a(sussasa{sv}i)" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList &lt; Notification &gt; "/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList &lt; NotificationData &gt; "/>
     </method>
   </interface>
 </node>


### PR DESCRIPTION
This commit introduces a NotificationData class, that is used to carry the
data of a Notification through DBus. It also fixes the inability to compile in
Debug mode.