### PR TITLE
[nemo-qml-plugin-notifications] Support detailed body text for previews

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -40,6 +40,7 @@ const char *HINT_CATEGORY = "category";
 const char *HINT_ITEM_COUNT = "x-nemo-item-count";
 const char *HINT_TIMESTAMP = "x-nemo-timestamp";
 const char *HINT_PREVIEW_BODY = "x-nemo-preview-body";
+const char *HINT_PREVIEW_BODY_DETAIL = "x-nemo-preview-body-detail";
 const char *HINT_PREVIEW_SUMMARY = "x-nemo-preview-summary";
 const char *HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-action-";
 const char *HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote-action-icon-";
@@ -411,6 +412,24 @@ void Notification::setPreviewBody(const QString &previewBody)
     if (previewBody != this->previewBody()) {
         hints_.insert(HINT_PREVIEW_BODY, previewBody);
         emit previewBodyChanged();
+    }
+}
+
+/*!
+    \qmlproperty QString Notification::previewBodyDetail
+
+    Detailed body text to be shown when the preview for the notification provides a detailed view, if any. Defaults to an empty string.
+ */
+QString Notification::previewBodyDetail() const
+{
+    return hints_.value(HINT_PREVIEW_BODY_DETAIL).toString();
+}
+
+void Notification::setPreviewBodyDetail(const QString &previewBodyDetail)
+{
+    if (previewBodyDetail != this->previewBodyDetail()) {
+        hints_.insert(HINT_PREVIEW_BODY_DETAIL, previewBodyDetail);
+        emit previewBodyDetailChanged();
     }
 }
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -73,6 +73,10 @@ public:
     QString previewBody() const;
     void setPreviewBody(const QString &previewBody);
 
+    Q_PROPERTY(QString previewBodyDetail READ previewBodyDetail WRITE setPreviewBodyDetail NOTIFY previewBodyDetailChanged)
+    QString previewBodyDetail() const;
+    void setPreviewBodyDetail(const QString &previewBodyDetail);
+
     Q_PROPERTY(int itemCount READ itemCount WRITE setItemCount NOTIFY itemCountChanged)
     int itemCount() const;
     void setItemCount(int itemCount);
@@ -124,6 +128,7 @@ signals:
     void timestampChanged();
     void previewSummaryChanged();
     void previewBodyChanged();
+    void previewBodyDetailChanged();
     void itemCountChanged();
     void remoteActionsChanged();
     void remoteDBusCallChanged();


### PR DESCRIPTION
If the preview mechanism offers an option to see more detail, this
hint should be used to provide the detailed version of the preview
body.