### PR TITLE
[nemo-qml-plugin-notifications] Workaround crash caused by 0.0.9

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -139,7 +139,6 @@ private:
     uint replacesId_;
     QString summary_;
     QString body_;
-    QHash<QString, QString> actions_;
     QVariantHash hints_;
     QVariantList remoteActions_;
     QString remoteDBusCallServiceName_;
@@ -147,6 +146,7 @@ private:
     QString remoteDBusCallInterface_;
     QString remoteDBusCallMethodName_;
     QVariantList remoteDBusCallArguments_;
+    QHash<QString, QString> actions_;
 };
 
 Q_DECLARE_METATYPE(Notification)


### PR DESCRIPTION
One particular closed source application generated a repeatable
crash with version 0.0.9, ending in the following stack trace:

 #0  0x42b26808 in __GI_raise (sig=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:67
 #1  0x42b2a590 in __GI_abort () at abort.c:91
 #2  0x42b61740 in __libc_message (do_abort=2, fmt=0x42c25e58 "*** glibc detected *** %s: %s: 0x%s ***\n") at ../sysdeps/unix/sysv/linux/libc_fatal.c:201
 #3  0x42b6c154 in malloc_printerr (action=3, str=0x42c26064 "free(): invalid pointer", ptr=<optimized out>) at malloc.c:5047
 #4  0x4b2ea51c in deallocate (data=<optimized out>) at /usr/include/qt5/QtCore/qarraydata.h:230
 #5  ~QString (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/qt5/QtCore/qstring.h:921
 #6  ~QString (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/nemonotifications-qt5/notification.h:41
 #7  ~Notification (this=0x4dd38138, __in_chrg=<optimized out>) at /usr/include/nemonotifications-qt5/notification.h:41
 #8  Notification::~Notification (this=0x4dd38138, __in_chrg=<optimized out>) at /usr/include/nemonotifications-qt5/notification.h:41
 #9  0x4b543c1c in QtMetaTypePrivate::QMetaTypeFunctionHelper<Notification, true>::Delete (t=<optimized out>) at /usr/include/qt5/QtCore/qmetatype.h:713
 #10 0x4243b048 in customTypeDestroyer (where=0x4dd38138, type=<optimized out>) at kernel/qmetatype.cpp:1657
 #11 delegate (where=0x4dd38138, this=<synthetic pointer>) at kernel/qmetatype.cpp:1643
 #12 switcher<void, {anonymous}::TypeDestroyer> (data=0x4dd38138, type=<optimized out>, logic=<synthetic pointer>) at kernel/qmetatypeswitcher_p.h:83
 #13 QMetaType::destroy (type=<optimized out>, data=0x4dd38138) at kernel/qmetatype.cpp:1673
 #14 0x42467e88 in (anonymous namespace)::customClear (d=0xbea76ba8) at kernel/qvariant.cpp:886
 #15 0x42468290 in ~QVariant (this=0xbea76ba8, __in_chrg=<optimized out>) at kernel/qvariant.cpp:1208
 #16 QVariant::~QVariant (this=0xbea76ba8, __in_chrg=<optimized out>) at kernel/qvariant.cpp:1205
 #17 0x41f73468 in QDBusArgumentPrivate::createSignature (id=1899) at qdbusargument.cpp:105
 #18 0x41f7b1f8 in QDBusMetaType::typeToSignature (type=<optimized out>) at qdbusmetatype.cpp:462
 #19 0x41f73940 in beginArray (id=1899, this=0x4f49cbe8) at qdbusmarshaller.cpp:237
 #20 QDBusArgument::beginArray (this=0xbea76cd0, id=1899) at qdbusargument.cpp:868
 #21 0x4b547014 in operator<< <Notification> (list=..., arg=...) at /usr/include/qt5/QtDBus/qdbusargument.h:264
 #22 qDBusMarshallHelper<QList<Notification> > (arg=..., t=0xbea76cb8) at /usr/include/qt5/QtDBus/qdbusmetatype.h:69
 #23 0x41f7b964 in QDBusMetaType::marshall (arg=..., id=<optimized out>, data=0xbea76cb8) at qdbusmetatype.cpp:251
 #24 0x41f733a8 in QDBusArgumentPrivate::createSignature (id=1900) at qdbusargument.cpp:82
 #25 0x41f7b1f8 in QDBusMetaType::typeToSignature (type=<optimized out>) at qdbusmetatype.cpp:462
 #26 0x41f86418 in QDBusPendingCallPrivate::setMetaTypes (this=0x4f456a80, count=1, types=<optimized out>) at qdbuspendingcall.cpp:199
 #27 0x41f884c4 in QDBusPendingReplyData::setMetaTypes (this=0xbea76dcc, count=1, types=0xbea76d88) at qdbuspendingreply.cpp:293
 #28 0x4b548834 in calculateMetaTypes (this=0xbea76dcc) at /usr/include/qt5/QtDBus/qdbuspendingreply.h:195
 #29 assign (call=..., this=0xbea76dcc) at /usr/include/qt5/QtDBus/qdbuspendingreply.h:201
 #30 operator= (call=..., this=0xbea76dcc) at /usr/include/qt5/QtDBus/qdbuspendingreply.h:144
 #31 QDBusPendingReply (call=..., this=0xbea76dcc) at /usr/include/qt5/QtDBus/qdbuspendingreply.h:138
 #32 NotificationManagerProxy::GetNotifications (this=<optimized out>, app_name=...) at notificationmanagerproxy.h:57
 #33 0x4b5412e8 in Notification::notifications () at notification.cpp:665

It may be an error in the application's use of QDBus, but in any case
the problem is not reproducible with the layout change in this commit.