### PR TITLE
Notification data separation

### DIFF
--- a/rpm/nemo-qml-plugin-notifications-qt5.spec
+++ b/rpm/nemo-qml-plugin-notifications-qt5.spec
@@ -54,7 +54,7 @@ BuildRequires: qt5-plugin-sqldriver-sqlite
 # >> build pre
 # << build pre
 
-%qmake5 
+%qmake5 VERSION=%{version}
 
 make %{?jobs:-j%jobs}
 make docs

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -228,12 +228,6 @@ class NotificationPrivate : public NotificationData
     {
     }
 
-    NotificationPrivate &operator=(const NotificationData &data)
-    {
-        *this = NotificationPrivate(data);
-        return *this;
-    }
-
     QVariantMap firstRemoteAction() const
     {
         QVariantMap vm;
@@ -337,6 +331,14 @@ class NotificationPrivate : public NotificationData
 Notification::Notification(QObject *parent) :
     QObject(parent),
     d_ptr(new NotificationPrivate)
+{
+    connect(notificationManager(), SIGNAL(ActionInvoked(uint,QString)), this, SLOT(checkActionInvoked(uint,QString)));
+    connect(notificationManager(), SIGNAL(NotificationClosed(uint,uint)), this, SLOT(checkNotificationClosed(uint,uint)));
+}
+
+Notification::Notification(const NotificationData &data, QObject *parent) :
+    QObject(parent),
+    d_ptr(new NotificationPrivate(data))
 {
     connect(notificationManager(), SIGNAL(ActionInvoked(uint,QString)), this, SLOT(checkActionInvoked(uint,QString)));
     connect(notificationManager(), SIGNAL(NotificationClosed(uint,uint)), this, SLOT(checkNotificationClosed(uint,uint)));
@@ -858,9 +860,7 @@ QList<QObject*> Notification::notifications(const QString &appName)
 
 Notification *Notification::createNotification(const NotificationData &data, QObject *parent)
 {
-    Notification *notification = new Notification(parent);
-    *notification->d_func() = data;
-    return notification;
+    return new Notification(data, parent);
 }
 
 QDBusArgument &operator<<(QDBusArgument &argument, const NotificationData &data)

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -336,7 +336,7 @@ class NotificationPrivate : public NotificationData
  */
 Notification::Notification(QObject *parent) :
     QObject(parent),
-    data(new NotificationPrivate)
+    d_ptr(new NotificationPrivate)
 {
     connect(notificationManager(), SIGNAL(ActionInvoked(uint,QString)), this, SLOT(checkActionInvoked(uint,QString)));
     connect(notificationManager(), SIGNAL(NotificationClosed(uint,uint)), this, SLOT(checkNotificationClosed(uint,uint)));
@@ -344,6 +344,7 @@ Notification::Notification(QObject *parent) :
 
 Notification::~Notification()
 {
+    delete d_ptr;
 }
 
 /*!
@@ -353,13 +354,15 @@ Notification::~Notification()
  */
 QString Notification::category() const
 {
-    return data->hints.value(HINT_CATEGORY).toString();
+    Q_D(const Notification);
+    return d->hints.value(HINT_CATEGORY).toString();
 }
 
 void Notification::setCategory(const QString &category)
 {
+    Q_D(Notification);
     if (category != this->category()) {
-        data->hints.insert(HINT_CATEGORY, category);
+        d->hints.insert(HINT_CATEGORY, category);
         emit categoryChanged();
     }
 }
@@ -374,13 +377,15 @@ void Notification::setCategory(const QString &category)
  */
 QString Notification::appName() const
 {
-    return !data->appName.isEmpty() ? data->appName : processName();
+    Q_D(const Notification);
+    return !d->appName.isEmpty() ? d->appName : processName();
 }
 
 void Notification::setAppName(const QString &appName)
 {
+    Q_D(Notification);
     if (appName != this->appName()) {
-        data->appName = appName;
+        d->appName = appName;
         emit appNameChanged();
     }
 }
@@ -392,13 +397,15 @@ void Notification::setAppName(const QString &appName)
  */
 uint Notification::replacesId() const
 {
-    return data->replacesId;
+    Q_D(const Notification);
+    return d->replacesId;
 }
 
 void Notification::setReplacesId(uint id)
 {
-    if (data->replacesId != id) {
-        data->replacesId = id;
+    Q_D(Notification);
+    if (d->replacesId != id) {
+        d->replacesId = id;
         emit replacesIdChanged();
     }
 }
@@ -410,13 +417,15 @@ void Notification::setReplacesId(uint id)
  */
 QString Notification::appIcon() const
 {
-    return data->appIcon;
+    Q_D(const Notification);
+    return d->appIcon;
 }
 
 void Notification::setAppIcon(const QString &appIcon)
 {
+    Q_D(Notification);
     if (appIcon != this->appIcon()) {
-        data->appIcon = appIcon;
+        d->appIcon = appIcon;
         emit appIconChanged();
     }
 }
@@ -428,13 +437,15 @@ void Notification::setAppIcon(const QString &appIcon)
  */
 QString Notification::summary() const
 {
-    return data->summary;
+    Q_D(const Notification);
+    return d->summary;
 }
 
 void Notification::setSummary(const QString &summary)
 {
-    if (data->summary != summary) {
-        data->summary = summary;
+    Q_D(Notification);
+    if (d->summary != summary) {
+        d->summary = summary;
         emit summaryChanged();
     }
 }
@@ -446,13 +457,15 @@ void Notification::setSummary(const QString &summary)
  */
 QString Notification::body() const
 {
-    return data->body;
+    Q_D(const Notification);
+    return d->body;
 }
 
 void Notification::setBody(const QString &body)
 {
-    if (data->body != body) {
-        data->body = body;
+    Q_D(Notification);
+    if (d->body != body) {
+        d->body = body;
         emit bodyChanged();
     }
 }
@@ -467,13 +480,15 @@ void Notification::setBody(const QString &body)
  */
 qint32 Notification::expireTimeout() const
 {
-    return data->expireTimeout;
+    Q_D(const Notification);
+    return d->expireTimeout;
 }
 
 void Notification::setExpireTimeout(qint32 milliseconds)
 {
-    if (milliseconds != data->expireTimeout) {
-        data->expireTimeout = milliseconds;
+    Q_D(Notification);
+    if (milliseconds != d->expireTimeout) {
+        d->expireTimeout = milliseconds;
         emit expireTimeoutChanged();
     }
 }
@@ -485,13 +500,15 @@ void Notification::setExpireTimeout(qint32 milliseconds)
  */
 QDateTime Notification::timestamp() const
 {
-    return data->hints.value(HINT_TIMESTAMP).toDateTime();
+    Q_D(const Notification);
+    return d->hints.value(HINT_TIMESTAMP).toDateTime();
 }
 
 void Notification::setTimestamp(const QDateTime &timestamp)
 {
+    Q_D(Notification);
     if (timestamp != this->timestamp()) {
-        data->hints.insert(HINT_TIMESTAMP, timestamp.toString(Qt::ISODate));
+        d->hints.insert(HINT_TIMESTAMP, timestamp.toString(Qt::ISODate));
         emit timestampChanged();
     }
 }
@@ -503,13 +520,15 @@ void Notification::setTimestamp(const QDateTime &timestamp)
  */
 QString Notification::previewSummary() const
 {
-    return data->hints.value(HINT_PREVIEW_SUMMARY).toString();
+    Q_D(const Notification);
+    return d->hints.value(HINT_PREVIEW_SUMMARY).toString();
 }
 
 void Notification::setPreviewSummary(const QString &previewSummary)
 {
+    Q_D(Notification);
     if (previewSummary != this->previewSummary()) {
-        data->hints.insert(HINT_PREVIEW_SUMMARY, previewSummary);
+        d->hints.insert(HINT_PREVIEW_SUMMARY, previewSummary);
         emit previewSummaryChanged();
     }
 }
@@ -521,13 +540,15 @@ void Notification::setPreviewSummary(const QString &previewSummary)
  */
 QString Notification::previewBody() const
 {
-    return data->hints.value(HINT_PREVIEW_BODY).toString();
+    Q_D(const Notification);
+    return d->hints.value(HINT_PREVIEW_BODY).toString();
 }
 
 void Notification::setPreviewBody(const QString &previewBody)
 {
+    Q_D(Notification);
     if (previewBody != this->previewBody()) {
-        data->hints.insert(HINT_PREVIEW_BODY, previewBody);
+        d->hints.insert(HINT_PREVIEW_BODY, previewBody);
         emit previewBodyChanged();
     }
 }
@@ -539,13 +560,15 @@ void Notification::setPreviewBody(const QString &previewBody)
  */
 int Notification::itemCount() const
 {
-    return data->hints.value(HINT_ITEM_COUNT).toInt();
+    Q_D(const Notification);
+    return d->hints.value(HINT_ITEM_COUNT).toInt();
 }
 
 void Notification::setItemCount(int itemCount)
 {
+    Q_D(Notification);
     if (itemCount != this->itemCount()) {
-        data->hints.insert(HINT_ITEM_COUNT, itemCount);
+        d->hints.insert(HINT_ITEM_COUNT, itemCount);
         emit itemCountChanged();
     }
 }
@@ -559,8 +582,9 @@ void Notification::setItemCount(int itemCount)
 */
 void Notification::publish()
 {
-    setReplacesId(notificationManager()->Notify(appName(), data->replacesId, data->appIcon, data->summary, data->body,
-                                                encodeActions(data->actions), data->hints, data->expireTimeout));
+    Q_D(Notification);
+    setReplacesId(notificationManager()->Notify(appName(), d->replacesId, d->appIcon, d->summary, d->body,
+                                                encodeActions(d->actions), d->hints, d->expireTimeout));
 }
 
 /*!
@@ -570,8 +594,9 @@ void Notification::publish()
 */
 void Notification::close()
 {
-    if (data->replacesId != 0) {
-        notificationManager()->CloseNotification(data->replacesId);
+    Q_D(Notification);
+    if (d->replacesId != 0) {
+        notificationManager()->CloseNotification(d->replacesId);
         setReplacesId(0);
     }
 }
@@ -583,7 +608,8 @@ void Notification::close()
 */
 void Notification::checkActionInvoked(uint id, QString actionKey)
 {
-    if (id == data->replacesId) {
+    Q_D(Notification);
+    if (id == d->replacesId) {
         if (actionKey == DEFAULT_ACTION_NAME) {
             emit clicked();
         }
@@ -600,7 +626,8 @@ void Notification::checkActionInvoked(uint id, QString actionKey)
 */
 void Notification::checkNotificationClosed(uint id, uint reason)
 {
-    if (id == data->replacesId) {
+    Q_D(Notification);
+    if (id == d->replacesId) {
         emit closed(reason);
         setReplacesId(0);
     }
@@ -613,16 +640,18 @@ void Notification::checkNotificationClosed(uint id, uint reason)
  */
 QString Notification::remoteDBusCallServiceName() const
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(const Notification);
+    QVariantMap vm(d->firstRemoteAction());
     return vm["name"].value<QString>();
 }
 
 void Notification::setRemoteDBusCallServiceName(const QString &serviceName)
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(Notification);
+    QVariantMap vm(d->firstRemoteAction());
     if (vm["name"].value<QString>() != serviceName) {
         vm.insert("name", serviceName);
-        data->setFirstRemoteAction(vm);
+        d->setFirstRemoteAction(vm);
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
@@ -636,16 +665,18 @@ void Notification::setRemoteDBusCallServiceName(const QString &serviceName)
  */
 QString Notification::remoteDBusCallObjectPath() const
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(const Notification);
+    QVariantMap vm(d->firstRemoteAction());
     return vm["path"].value<QString>();
 }
 
 void Notification::setRemoteDBusCallObjectPath(const QString &objectPath)
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(Notification);
+    QVariantMap vm(d->firstRemoteAction());
     if (vm["path"].value<QString>() != objectPath) {
         vm.insert("path", objectPath);
-        data->setFirstRemoteAction(vm);
+        d->setFirstRemoteAction(vm);
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
@@ -659,16 +690,18 @@ void Notification::setRemoteDBusCallObjectPath(const QString &objectPath)
  */
 QString Notification::remoteDBusCallInterface() const
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(const Notification);
+    QVariantMap vm(d->firstRemoteAction());
     return vm["iface"].value<QString>();
 }
 
 void Notification::setRemoteDBusCallInterface(const QString &interface)
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(Notification);
+    QVariantMap vm(d->firstRemoteAction());
     if (vm["iface"].value<QString>() != interface) {
         vm.insert("iface", interface);
-        data->setFirstRemoteAction(vm);
+        d->setFirstRemoteAction(vm);
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
@@ -682,16 +715,18 @@ void Notification::setRemoteDBusCallInterface(const QString &interface)
  */
 QString Notification::remoteDBusCallMethodName() const
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(const Notification);
+    QVariantMap vm(d->firstRemoteAction());
     return vm["method"].value<QString>();
 }
 
 void Notification::setRemoteDBusCallMethodName(const QString &methodName)
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(Notification);
+    QVariantMap vm(d->firstRemoteAction());
     if (vm["method"].value<QString>() != methodName) {
         vm.insert("method", methodName);
-        data->setFirstRemoteAction(vm);
+        d->setFirstRemoteAction(vm);
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
@@ -705,16 +740,18 @@ void Notification::setRemoteDBusCallMethodName(const QString &methodName)
  */
 QVariantList Notification::remoteDBusCallArguments() const
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(const Notification);
+    QVariantMap vm(d->firstRemoteAction());
     return vm["arguments"].value<QVariantList>();
 }
 
 void Notification::setRemoteDBusCallArguments(const QVariantList &arguments)
 {
-    QVariantMap vm(data->firstRemoteAction());
+    Q_D(Notification);
+    QVariantMap vm(d->firstRemoteAction());
     if (vm["arguments"].value<QVariantList>() != arguments) {
         vm.insert("arguments", arguments);
-        data->setFirstRemoteAction(vm);
+        d->setFirstRemoteAction(vm);
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
@@ -728,35 +765,37 @@ void Notification::setRemoteDBusCallArguments(const QVariantList &arguments)
  */
 QVariantList Notification::remoteActions() const
 {
-    return data->remoteActions;
+    Q_D(const Notification);
+    return d->remoteActions;
 }
 
 void Notification::setRemoteActions(const QVariantList &remoteActions)
 {
-    if (remoteActions != data->remoteActions) {
+    Q_D(Notification);
+    if (remoteActions != d->remoteActions) {
         // Remove any existing actions
-        foreach (const QVariant &action, data->remoteActions) {
+        foreach (const QVariant &action, d->remoteActions) {
             QVariantMap vm = action.value<QVariantMap>();
             const QString actionName = vm["name"].value<QString>();
             if (!actionName.isEmpty()) {
-                data->hints.remove(QString(HINT_REMOTE_ACTION_PREFIX) + actionName);
-                data->actions.remove(actionName);
+                d->hints.remove(QString(HINT_REMOTE_ACTION_PREFIX) + actionName);
+                d->actions.remove(actionName);
             }
         }
 
         // Add the new actions and their associated hints
-        data->remoteActions = remoteActions;
+        d->remoteActions = remoteActions;
 
         QPair<QHash<QString, QString>, QVariantHash> actionHints = encodeActionHints(remoteActions);
 
         QHash<QString, QString>::const_iterator ait = actionHints.first.constBegin(), aend = actionHints.first.constEnd();
         for ( ; ait != aend; ++ait) {
-            data->actions.insert(ait.key(), ait.value());
+            d->actions.insert(ait.key(), ait.value());
         }
 
         QVariantHash::const_iterator hit = actionHints.second.constBegin(), hend = actionHints.second.constEnd();
         for ( ; hit != hend; ++hit) {
-            data->hints.insert(hit.key(), hit.value());
+            d->hints.insert(hit.key(), hit.value());
         }
 
         emit remoteActionsChanged();
@@ -771,7 +810,8 @@ void Notification::setRemoteActions(const QVariantList &remoteActions)
 */
 QVariant Notification::hintValue(const QString &hint) const
 {
-    return data->hints.value(hint);
+    Q_D(const Notification);
+    return d->hints.value(hint);
 }
 
 /*!
@@ -781,7 +821,8 @@ QVariant Notification::hintValue(const QString &hint) const
 */
 void Notification::setHintValue(const QString &hint, const QVariant &value)
 {
-    data->hints.insert(hint, value);
+    Q_D(Notification);
+    d->hints.insert(hint, value);
 }
 
 /*!
@@ -818,7 +859,7 @@ QList<QObject*> Notification::notifications(const QString &appName)
 Notification *Notification::createNotification(const NotificationData &data, QObject *parent)
 {
     Notification *notification = new Notification(parent);
-    *notification->data = data;
+    *notification->d_func() = data;
     return notification;
 }
 

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -212,6 +212,35 @@ NotificationData::NotificationData()
 {
 }
 
+class NotificationPrivate : public NotificationData
+{
+    friend class Notification;
+
+    NotificationPrivate()
+        : NotificationData()
+    {
+    }
+
+    NotificationPrivate(const NotificationData &data)
+        : NotificationData(data)
+        , remoteActions(decodeActionHints(actions, hints))
+    {
+    }
+
+    NotificationPrivate &operator=(const NotificationData &data)
+    {
+        *this = NotificationPrivate(data);
+        return *this;
+    }
+
+    QVariantList remoteActions;
+    QString remoteDBusCallServiceName;
+    QString remoteDBusCallObjectPath;
+    QString remoteDBusCallInterface;
+    QString remoteDBusCallMethodName;
+    QVariantList remoteDBusCallArguments;
+};
+
 /*!
     \qmltype Notification
     \brief Allows notifications to be published
@@ -290,7 +319,7 @@ NotificationData::NotificationData()
  */
 Notification::Notification(QObject *parent) :
     QObject(parent),
-    data(new NotificationData)
+    data(new NotificationPrivate)
 {
     connect(notificationManager(), SIGNAL(ActionInvoked(uint,QString)), this, SLOT(checkActionInvoked(uint,QString)));
     connect(notificationManager(), SIGNAL(NotificationClosed(uint,uint)), this, SLOT(checkNotificationClosed(uint,uint)));
@@ -730,7 +759,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, NotificationData 
     argument.endStructure();
 
     data.actions = decodeActions(tempStringList);
-    data.remoteActions = decodeActionHints(data.actions, data.hints);
 
     return argument;
 }
+

--- a/src/notification.h
+++ b/src/notification.h
@@ -38,12 +38,31 @@
 #include <QVariantHash>
 #include <QDBusArgument>
 
+struct NotificationData
+{
+    NotificationData();
+
+    uint replacesId;
+    QString summary;
+    QString body;
+    QHash<QString, QString> actions;
+    QVariantHash hints;
+    QVariantList remoteActions;
+    QString remoteDBusCallServiceName;
+    QString remoteDBusCallObjectPath;
+    QString remoteDBusCallInterface;
+    QString remoteDBusCallMethodName;
+    QVariantList remoteDBusCallArguments;
+};
+
+class NotificationManagerProxy;
 class Q_DECL_EXPORT Notification : public QObject
 {
     Q_OBJECT
 
 public:
-    Notification(QObject *parent = 0);
+    explicit Notification(QObject *parent = 0);
+    virtual ~Notification();
 
     Q_PROPERTY(QString category READ category WRITE setCategory NOTIFY categoryChanged)
     QString category() const;
@@ -111,8 +130,6 @@ public:
     Q_INVOKABLE static QList<QObject*> notifications();
 
     explicit Notification(const Notification &notification);
-    friend QDBusArgument &operator<<(QDBusArgument &, const Notification &);
-    friend const QDBusArgument &operator>>(const QDBusArgument &, Notification &);
 
 signals:
     void clicked();
@@ -128,29 +145,22 @@ signals:
     void remoteActionsChanged();
     void remoteDBusCallChanged();
 
+protected:
+    QScopedPointer<NotificationData> data;
+
 private slots:
     void checkActionInvoked(uint id, QString actionKey);
     void checkNotificationClosed(uint id, uint reason);
     void setRemoteActionHint();
 
 private:
-    static QString appName();
-
-    uint replacesId_;
-    QString summary_;
-    QString body_;
-    QHash<QString, QString> actions_;
-    QVariantHash hints_;
-    QVariantList remoteActions_;
-    QString remoteDBusCallServiceName_;
-    QString remoteDBusCallObjectPath_;
-    QString remoteDBusCallInterface_;
-    QString remoteDBusCallMethodName_;
-    QVariantList remoteDBusCallArguments_;
+    static Notification *createNotification(const NotificationData &data, QObject *parent = 0);
 };
 
-Q_DECLARE_METATYPE(Notification)
-Q_DECLARE_METATYPE(QList<Notification>)
-Q_DECLARE_METATYPE(QList<Notification*>)
+QDBusArgument &operator<<(QDBusArgument &, const NotificationData &);
+const QDBusArgument &operator>>(const QDBusArgument &, NotificationData &);
+
+Q_DECLARE_METATYPE(NotificationData)
+Q_DECLARE_METATYPE(QList<NotificationData>)
 
 #endif // NOTIFICATION_H

--- a/src/notification.h
+++ b/src/notification.h
@@ -141,8 +141,6 @@ public:
     Q_INVOKABLE static QList<QObject*> notifications();
     Q_INVOKABLE static QList<QObject*> notifications(const QString &appName);
 
-    explicit Notification(const Notification &notification);
-
 signals:
     void clicked();
     void closed(uint reason);
@@ -167,6 +165,8 @@ private slots:
 private:
     NotificationPrivate * const d_ptr;
     Q_DECLARE_PRIVATE(Notification)
+
+    Notification(const NotificationData &data, QObject *parent = 0);
 
     static Notification *createNotification(const NotificationData &data, QObject *parent = 0);
 };

--- a/src/notification.h
+++ b/src/notification.h
@@ -47,15 +47,10 @@ struct NotificationData
     QString body;
     QHash<QString, QString> actions;
     QVariantHash hints;
-    QVariantList remoteActions;
-    QString remoteDBusCallServiceName;
-    QString remoteDBusCallObjectPath;
-    QString remoteDBusCallInterface;
-    QString remoteDBusCallMethodName;
-    QVariantList remoteDBusCallArguments;
 };
 
 class NotificationManagerProxy;
+class NotificationPrivate;
 class Q_DECL_EXPORT Notification : public QObject
 {
     Q_OBJECT
@@ -146,7 +141,7 @@ signals:
     void remoteDBusCallChanged();
 
 protected:
-    QScopedPointer<NotificationData> data;
+    QScopedPointer<NotificationPrivate> data;
 
 private slots:
     void checkActionInvoked(uint id, QString actionKey);

--- a/src/notification.h
+++ b/src/notification.h
@@ -166,7 +166,6 @@ protected:
 private slots:
     void checkActionInvoked(uint id, QString actionKey);
     void checkNotificationClosed(uint id, uint reason);
-    void setRemoteActionHint();
 
 private:
     static Notification *createNotification(const NotificationData &data, QObject *parent = 0);

--- a/src/notification.h
+++ b/src/notification.h
@@ -42,11 +42,14 @@ struct NotificationData
 {
     NotificationData();
 
-    uint replacesId;
+    QString appName;
+    quint32 replacesId;
+    QString appIcon;
     QString summary;
     QString body;
     QHash<QString, QString> actions;
     QVariantHash hints;
+    qint32 expireTimeout;
 };
 
 class NotificationManagerProxy;
@@ -63,9 +66,17 @@ public:
     QString category() const;
     void setCategory(const QString &category);
 
-    Q_PROPERTY(uint replacesId READ replacesId WRITE setReplacesId NOTIFY replacesIdChanged)
-    uint replacesId() const;
-    void setReplacesId(uint id);
+    Q_PROPERTY(QString appName READ appName WRITE setAppName NOTIFY appNameChanged)
+    QString appName() const;
+    void setAppName(const QString &appName);
+
+    Q_PROPERTY(quint32 replacesId READ replacesId WRITE setReplacesId NOTIFY replacesIdChanged)
+    quint32 replacesId() const;
+    void setReplacesId(quint32 id);
+
+    Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+    QString appIcon() const;
+    void setAppIcon(const QString &appIcon);
 
     Q_PROPERTY(QString summary READ summary WRITE setSummary NOTIFY summaryChanged)
     QString summary() const;
@@ -74,6 +85,10 @@ public:
     Q_PROPERTY(QString body READ body WRITE setBody NOTIFY bodyChanged)
     QString body() const;
     void setBody(const QString &body);
+
+    Q_PROPERTY(qint32 expireTimeout READ expireTimeout WRITE setExpireTimeout NOTIFY expireTimeoutChanged)
+    qint32 expireTimeout() const;
+    void setExpireTimeout(qint32 milliseconds);
 
     Q_PROPERTY(QDateTime timestamp READ timestamp WRITE setTimestamp NOTIFY timestampChanged)
     QDateTime timestamp() const;
@@ -122,7 +137,9 @@ public:
 
     Q_INVOKABLE void publish();
     Q_INVOKABLE void close();
+
     Q_INVOKABLE static QList<QObject*> notifications();
+    Q_INVOKABLE static QList<QObject*> notifications(const QString &appName);
 
     explicit Notification(const Notification &notification);
 
@@ -130,9 +147,12 @@ signals:
     void clicked();
     void closed(uint reason);
     void categoryChanged();
+    void appNameChanged();
     void replacesIdChanged();
+    void appIconChanged();
     void summaryChanged();
     void bodyChanged();
+    void expireTimeoutChanged();
     void timestampChanged();
     void previewSummaryChanged();
     void previewBodyChanged();

--- a/src/notification.h
+++ b/src/notification.h
@@ -160,14 +160,14 @@ signals:
     void remoteActionsChanged();
     void remoteDBusCallChanged();
 
-protected:
-    QScopedPointer<NotificationPrivate> data;
-
 private slots:
     void checkActionInvoked(uint id, QString actionKey);
     void checkNotificationClosed(uint id, uint reason);
 
 private:
+    NotificationPrivate * const d_ptr;
+    Q_DECLARE_PRIVATE(Notification)
+
     static Notification *createNotification(const NotificationData &data, QObject *parent = 0);
 };
 

--- a/src/org.freedesktop.Notifications.xml
+++ b/src/org.freedesktop.Notifications.xml
@@ -39,7 +39,7 @@
     <method name="GetNotifications">
       <arg name="app_name" type="s" direction="in"/>
       <arg name="notifications" type="a(sussasa{sv}i)" direction="out"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList &lt; Notification &gt; "/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList &lt; NotificationData &gt; "/>
     </method>
   </interface>
 </node>

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,7 +1,6 @@
 system(qdbusxml2cpp org.freedesktop.Notifications.xml -p notificationmanagerproxy -c NotificationManagerProxy -i notification.h)
 
 TEMPLATE = lib
-VERSION = 0.0.9
 TARGET = nemonotifications-qt5
 CONFIG += qt hide_symbols create_pc create_prl
 QT += dbus


### PR DESCRIPTION
Rebases PR https://github.com/nemomobile/nemo-qml-plugin-notifications/pull/7 and extends it to move the data members of the Notification class into a private implementation class.

Also update the interface of the Notification to expose missing properties, and remove some redundancy in the internal representation. 