### PR TITLE
[nemo-qml-plugin-notifications] Add support for origin property

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -43,6 +43,7 @@ const char *HINT_PREVIEW_BODY = "x-nemo-preview-body";
 const char *HINT_PREVIEW_SUMMARY = "x-nemo-preview-summary";
 const char *HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-action-";
 const char *HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote-action-icon-";
+const char *HINT_ORIGIN = "x-nemo-origin";
 const char *DEFAULT_ACTION_NAME = "default";
 
 static inline QString processName() {
@@ -805,6 +806,27 @@ void Notification::setRemoteActions(const QVariantList &remoteActions)
 
         emit remoteActionsChanged();
         emit remoteDBusCallChanged();
+    }
+}
+
+/*!
+    \qmlproperty QString Notification::origin
+
+    A property indicating the origin of the notification.
+    For example, the email address from which a mail was received that caused the notification to be created.
+*/
+QString Notification::origin() const
+{
+    Q_D(const Notification);
+    return d->hints.value(HINT_ORIGIN).toString();
+}
+
+void Notification::setOrigin(const QString &origin)
+{
+    Q_D(Notification);
+    if (origin != this->origin()) {
+        d->hints.insert(HINT_ORIGIN, origin);
+        emit originChanged();
     }
 }
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -132,6 +132,10 @@ public:
     void setRemoteActions(const QVariantList &remoteActions);
     inline void setRemoteAction(const QVariant &remoteAction) { setRemoteActions(QVariantList() << remoteAction); }
 
+    Q_PROPERTY(QString origin READ origin WRITE setOrigin NOTIFY originChanged)
+    QString origin() const;
+    void setOrigin(const QString &origin);
+
     QVariant hintValue(const QString &hint) const;
     void setHintValue(const QString &hint, const QVariant &value);
 
@@ -157,6 +161,7 @@ signals:
     void itemCountChanged();
     void remoteActionsChanged();
     void remoteDBusCallChanged();
+    void originChanged();
 
 private slots:
     void checkActionInvoked(uint id, QString actionKey);


### PR DESCRIPTION
This property allows clients to inform the manager of the origin of
a notification; the interpretation of the property value is up to the
notification manager.