### PR TITLE
[nemo-qml-plugin-notifications] Minor API improvements

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -47,7 +47,8 @@ const char *HINT_ORIGIN = "x-nemo-origin";
 const char *DEFAULT_ACTION_NAME = "default";
 
 static inline QString processName() {
-    return QFileInfo(QCoreApplication::arguments()[0]).fileName();
+    // Defaults to the filename if not set
+    return QCoreApplication::applicationName();
 }
 
 //! A proxy for accessing the notification manager

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -885,6 +885,37 @@ QList<QObject*> Notification::notifications(const QString &appName)
     return objects;
 }
 
+QVariant Notification::remoteAction(const QString &name, const QString &displayName,
+                                    const QString &service, const QString &path, const QString &iface,
+                                    const QString &method, const QVariantList &arguments)
+{
+    QVariantMap action;
+
+    if (!name.isEmpty()) {
+        action.insert(QStringLiteral("name"), name);
+    }
+    if (!displayName.isEmpty()) {
+        action.insert(QStringLiteral("displayName"), displayName);
+    }
+    if (!service.isEmpty()) {
+        action.insert(QStringLiteral("service"), service);
+    }
+    if (!path.isEmpty()) {
+        action.insert(QStringLiteral("path"), path);
+    }
+    if (!iface.isEmpty()) {
+        action.insert(QStringLiteral("iface"), iface);
+    }
+    if (!method.isEmpty()) {
+        action.insert(QStringLiteral("method"), method);
+    }
+    if (!arguments.isEmpty()) {
+        action.insert(QStringLiteral("arguments"), arguments);
+    }
+
+    return action;
+}
+
 Notification *Notification::createNotification(const NotificationData &data, QObject *parent)
 {
     return new Notification(data, parent);

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -37,6 +37,7 @@
 namespace {
 
 const char *HINT_CATEGORY = "category";
+const char *HINT_URGENCY = "urgency";
 const char *HINT_ITEM_COUNT = "x-nemo-item-count";
 const char *HINT_TIMESTAMP = "x-nemo-timestamp";
 const char *HINT_PREVIEW_BODY = "x-nemo-preview-body";
@@ -474,6 +475,29 @@ void Notification::setBody(const QString &body)
     if (d->body != body) {
         d->body = body;
         emit bodyChanged();
+    }
+}
+
+/*!
+    \qmlproperty enumeration Notification::urgency
+
+    The urgency level of the notification.
+
+    Defaults to Normal urgency.
+ */
+Notification::Urgency Notification::urgency() const
+{
+    Q_D(const Notification);
+    // Clipping to bounds in case an invalid value is stored as a hint
+    return static_cast<Urgency>(qMax(static_cast<int>(Low), qMin(static_cast<int>(Critical), d->hints.value(HINT_URGENCY).toInt())));
+}
+
+void Notification::setUrgency(Urgency urgency)
+{
+    Q_D(Notification);
+    if (urgency != this->urgency()) {
+        d->hints.insert(HINT_URGENCY, static_cast<int>(urgency));
+        emit urgencyChanged();
     }
 }
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -57,8 +57,11 @@ class NotificationPrivate;
 class Q_DECL_EXPORT Notification : public QObject
 {
     Q_OBJECT
+    Q_ENUMS(Urgency)
 
 public:
+    enum Urgency { Low = 0, Normal = 1, Critical = 2 };
+
     explicit Notification(QObject *parent = 0);
     virtual ~Notification();
 
@@ -85,6 +88,10 @@ public:
     Q_PROPERTY(QString body READ body WRITE setBody NOTIFY bodyChanged)
     QString body() const;
     void setBody(const QString &body);
+
+    Q_PROPERTY(Urgency urgency READ urgency WRITE setUrgency NOTIFY urgencyChanged)
+    Urgency urgency() const;
+    void setUrgency(Urgency urgency);
 
     Q_PROPERTY(qint32 expireTimeout READ expireTimeout WRITE setExpireTimeout NOTIFY expireTimeoutChanged)
     qint32 expireTimeout() const;
@@ -158,6 +165,7 @@ signals:
     void appIconChanged();
     void summaryChanged();
     void bodyChanged();
+    void urgencyChanged();
     void expireTimeoutChanged();
     void timestampChanged();
     void previewSummaryChanged();

--- a/src/notification.h
+++ b/src/notification.h
@@ -145,6 +145,10 @@ public:
     Q_INVOKABLE static QList<QObject*> notifications();
     Q_INVOKABLE static QList<QObject*> notifications(const QString &appName);
 
+    Q_INVOKABLE static QVariant remoteAction(const QString &name, const QString &displayName,
+                                             const QString &service, const QString &path, const QString &iface,
+                                             const QString &method, const QVariantList &arguments = QVariantList());
+
 signals:
     void clicked();
     void closed(uint reason);


### PR DESCRIPTION
When providing the default application name for a notification, use the value set as application name in preference to the filename of the running executable.