### PR TITLE
[nemo-qml-plugin-notifications] Separate appName from notification ownership

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -150,7 +150,7 @@ public:
     Q_INVOKABLE void close();
 
     Q_INVOKABLE static QList<QObject*> notifications();
-    Q_INVOKABLE static QList<QObject*> notifications(const QString &appName);
+    Q_INVOKABLE static QList<QObject*> notifications(const QString &owner);
 
     Q_INVOKABLE static QVariant remoteAction(const QString &name, const QString &displayName,
                                              const QString &service, const QString &path, const QString &iface,


### PR DESCRIPTION
Allow the appName property to be unspecified, without losing track of the ownership of notifications, as required for the notifications() function.

If appName is not specified, lipstick will attempt to determine the appropriate value from a matching .desktop entry.

See also: https://github.com/nemomobile/lipstick/pull/258
