### PR TITLE
[nemo-qml-plugin-notifications] Clear existing notifications on install

### DIFF
--- a/notifications.pro
+++ b/notifications.pro
@@ -7,3 +7,9 @@ src_plugins.depends = src
 SUBDIRS += src src_plugins
 
 include (doc/doc.pri)
+
+oneshot.files = oneshot/*
+oneshot.path = /usr/lib/oneshot.d
+
+INSTALLS += oneshot
+

--- a/oneshot/remove-existing-notifications
+++ b/oneshot/remove-existing-notifications
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Remove all existing notifications
+/usr/bin/notificationtool -o purge
+

--- a/rpm/nemo-qml-plugin-notifications-qt5.spec
+++ b/rpm/nemo-qml-plugin-notifications-qt5.spec
@@ -20,6 +20,8 @@ Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  oneshot
+%{_oneshot_requires_post}
 
 %description
 %{summary}.
@@ -68,11 +70,14 @@ rm -rf %{buildroot}
 %qmake_install
 mkdir -p %{buildroot}/%{_docdir}/%{name}
 cp -R doc/html/* %{buildroot}/%{_docdir}/%{name}/
+chmod +x %{buildroot}/%{_oneshotdir}/*
 
 # >> install post
 # << install post
 
-%post -p /sbin/ldconfig
+%post
+/sbin/ldconfig
+%{_bindir}/add-oneshot --now remove-existing-notifications
 
 %postun -p /sbin/ldconfig
 
@@ -81,6 +86,7 @@ cp -R doc/html/* %{buildroot}/%{_docdir}/%{name}/
 %{_libdir}/libnemonotifications-qt5.so.*
 %{_libdir}/qt5/qml/org/nemomobile/notifications/libnemonotifications.so
 %{_libdir}/qt5/qml/org/nemomobile/notifications/qmldir
+%{_oneshotdir}/*
 # >> files
 # << files
 


### PR DESCRIPTION
Notiifcations created by previous instances of this library used the 'appName' property of the notification as the identifier by which a process identified the notifications it created.  Now that appName is translated, as intended by the desktop notifications specification, the library instead uses a hint to record the process name of the notification creator.  Pre-existing notifications do not posses this hint, so they should all be removed at upgrade and recreated if necessary.